### PR TITLE
fix: Stereo wav reader bug fixed

### DIFF
--- a/androidlame/src/main/java/com/naman14/androidlame/WaveReader.java
+++ b/androidlame/src/main/java/com/naman14/androidlame/WaveReader.java
@@ -209,7 +209,7 @@ public class WaveReader {
         int bytesRead = mInStream.read(buf, 0, numSamples * 4);
 
         for (int i = 0; i < bytesRead; i+=2) {
-            short val = byteToShortLE(buf[0], buf[i+1]);
+            short val = byteToShortLE(buf[i], buf[i+1]);
             if (i % 4 == 0) {
                 left[index] = val;
             } else {


### PR DESCRIPTION
I was getting some strange sounding noise in my stereo wav files that were encoded to mp3.  After making this change, the noise has disappeared.